### PR TITLE
Decode legacy cookie values

### DIFF
--- a/Integration/LegacyCaptureResponseFactory.php
+++ b/Integration/LegacyCaptureResponseFactory.php
@@ -85,7 +85,9 @@ class LegacyCaptureResponseFactory
 
         $values = array(
             'name'           => trim($name),
-            'value'          => trim($value),
+            // Cookie value must be decoded, otherwise it is encoded again when we forward it to the Symfony response.
+            // That would lead to problems, for example with session cookies whose id can contain a comma.
+            'value'          => trim(urldecode($value)),
             'expires'        => 0,
             'path'           => '/',
             'domain'         => '',

--- a/Integration/LegacyCaptureResponseFactory.php
+++ b/Integration/LegacyCaptureResponseFactory.php
@@ -48,7 +48,7 @@ class LegacyCaptureResponseFactory
         $cookies = array();
 
         foreach ($headers as $header) {
-            $header = preg_match('(^([^:]+):(.*)$)', $header, $matches);
+            preg_match('(^([^:]+):(.*)$)', $header, $matches);
             $headerName = strtolower(trim($matches[1]));
             $headerValue = trim($matches[2]);
 

--- a/Integration/LegacyCaptureResponseFactory.php
+++ b/Integration/LegacyCaptureResponseFactory.php
@@ -90,8 +90,7 @@ class LegacyCaptureResponseFactory
             'path'           => '/',
             'domain'         => '',
             'secure'         => false,
-            'httponly'       => false,
-            'passedRawValue' => true,
+            'httponly'       => false
         );
 
         if (null !== $url) {


### PR DESCRIPTION
Decode cookie values from the legacy app before copying them to the Symfony response.

This avoids problems with cookies that contain "special" characters (for example commas in session IDs). 